### PR TITLE
Add gogid optional setting for installers

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -135,7 +135,7 @@ class ScriptInterpreter(CommandsMixin):
         self.game_name = self.script.get("custom-name") or installer["name"]
         self.game_slug = installer["game_slug"]
         self.steamid = installer.get("steamid")
-        self.gogid = installer.get("gogid")
+        self.gogid = self.script["game"]["gogid"] or installer.get("gogid")
 
         if not self.is_valid():
             raise ScriptingError(


### PR DESCRIPTION
This commit fixes an issue where GOG uses different game IDs for their
store page and the downloads themselves. This allows installer
maintainers to manage the gogid on a per installer basis. This will also
allow for different "editions" of the same game in GOG to be stored
under the same game entry on the Lutris website.

(closes #2594)